### PR TITLE
version 5.0.4 of kuali-common.  adds metadata.json in META-INF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kuali.pom</groupId>
         <artifactId>kuali-common</artifactId>
-        <version>4.3.10</version>
+        <version>5.0.4</version>
     </parent>
     <groupId>org.kuali.coeus</groupId>
     <artifactId>coeus-api</artifactId>


### PR DESCRIPTION
Version 5.0.4 captures a rich set of metadata about the build and writes it as JSON into:
META-INF/${project.groupId}/${project.artifactId}/metadata.json

Includes the build host, build JVM, SCM info, timestamp, GAV and other significant details of the Maven project model.